### PR TITLE
Graph API for interacting with ros2_tracing events

### DIFF
--- a/ros2_profiling_demo/scripts/profile_graph_summary.py
+++ b/ros2_profiling_demo/scripts/profile_graph_summary.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+import argparse
+import sys
+
+from ros2profile.api.process import load_mcap_data, load_event_graph
+
+
+def summarize(graph):
+    for node in graph.nodes():
+        print(f'Node: {node.name()}')
+        if node.publishers():
+            print(f'  Publishers: ')
+            for publisher in node.publishers():
+                print(f'    Topic: {publisher.topic_name()}')
+                print(f'      Events: {len(publisher.events())}')
+        if node.subscriptions():
+            print(f'  Subscriptions: ')
+            for subscription in node.subscriptions():
+                print(f'    Topic: {subscription.topic_name()}')
+                print(f'      Callback: {subscription.callback().symbol()}')
+        if node.timers():
+            print(f'  Timers: ')
+            for timer in node.timers():
+                print(f'    Period: {timer.period()}')
+                print(f'      Callback: {timer.callback().symbol()}')
+                print(f'      Events: {len(timer.callback().events())}')
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("profile", type=str, help="Profile directory")
+    args = parser.parse_args()
+    graph = load_event_graph(args.profile)
+    summarize(graph)
+
+if __name__ == '__main__':
+    main()

--- a/ros2profile/ros2profile/data/__init__.py
+++ b/ros2profile/ros2profile/data/__init__.py
@@ -1,0 +1,521 @@
+from .callback import Callback, CallbackEvent
+from .context import Context
+from .node import Node
+from .graph import Graph
+from .publisher import Publisher, PublishEvent
+from .subscription import Subscription, SubscriptionEvent
+from .timer import Timer
+
+from typing import List, Dict, Any
+
+import pandas as pd
+
+def build_graph(
+        event_data: Dict[str, Any],
+        callback_events: bool = True,
+        publish_events: bool = True,
+        subscription_events: bool = True,
+        ) -> Graph:
+    ret = Graph()
+
+    _build_contexts(ret, event_data)
+    _build_nodes(ret, event_data)
+    _build_callbacks(ret, event_data)
+    _build_publishers(ret, event_data)
+    _build_subscriptions(ret, event_data)
+    _build_timers(ret, event_data)
+
+    if callback_events:
+        _build_callback_events(ret, event_data)
+    if publish_events:
+        _build_publish_events(ret, event_data)
+    if subscription_events:
+        _build_subscription_events(ret, event_data)
+    if callback_events and subscription_events:
+        _associate_subscription_callbacks(ret, event_data)
+
+    return ret
+
+def _build_contexts(graph: Graph, event_data) -> None:
+    for event in event_data['ros2:rcl_init']:
+        graph.add_context(Context(event['context_handle'], event['version']))
+
+def _build_nodes(graph: Graph, event_data) -> None:
+    for event in event_data['ros2:rcl_node_init']:
+        node = Node(event['node_handle'], str(event['node_name']),
+            str(event['namespace']), event['rmw_handle'])
+        graph.add_node(node)
+
+def _build_callbacks(graph: Graph, event_data) -> None:
+    for event in event_data['ros2:rclcpp_callback_register']:
+        callback = Callback(event['callback'], str(event['symbol']))
+        callback._rclcpp_init_time = event['_timestamp']
+        graph.add_callback(callback)
+
+def _build_publishers(graph: Graph, event_data) -> None:
+    for event in event_data['ros2:rcl_publisher_init']:
+        pub = Publisher(event['publisher_handle'])
+        pub._rmw_handle = event['rmw_publisher_handle']
+        pub._node_handle = event['node_handle']
+        if pub._node_handle in graph._nodes:
+            pub._node = graph._nodes[pub._node_handle]
+        pub._topic_name = str(event['topic_name'])
+        pub._queue_depth = event['queue_depth']
+        pub._rcl_init_time = event['_timestamp']
+        graph.add_publisher(pub)
+
+    for event in event_data['ros2:rmw_publisher_init']:
+        pub = None
+        for p in graph._publishers.values():
+            if p._rmw_handle == event['rmw_publisher_handle']:
+                pub = p
+                break
+        if pub is None:
+            # print("Could not associate rmw publisher with rcl publisher")
+            continue
+        pub._rmw_init_time = event['_timestamp']
+        pub._gid = [*event['gid']][0:16]
+
+    for event in event_data['dds:create_writer']:
+        pub = None
+        for p in graph._publishers.values():
+            if p._gid == event['gid']:
+                pub = p
+                break
+        if pub is None:
+            # print(f"Could not associate dds writer: {event['topic_name']}")
+            continue
+
+        pub._dds_init_time = event['_timestamp']
+        pub._dds_topic_name = event['topic_name']
+        pub._dds_writer = event['writer']
+
+def _build_subscriptions(graph: Graph, event_data) -> None:
+    temp_subs = []
+    for event in event_data['ros2:rclcpp_subscription_init']:
+        sub = Subscription(event['subscription_handle'], event['subscription'])
+        sub._rclcpp_init_time = event['_timestamp']
+        temp_subs.append(sub)
+
+    for event in event_data['ros2:rcl_subscription_init']:
+        sub = None
+        for s in temp_subs:
+            if s._handle == event['subscription_handle']:
+                sub = s
+                break
+        if sub is None:
+            # print("Could not associate rcl subscription")
+            continue
+
+        sub._rmw_handle = event['rmw_subscription_handle']
+        sub._rcl_init_time = event['_timestamp']
+        sub._node_handle = event['node_handle']
+        if sub._node_handle in graph._nodes:
+            sub._node = graph._nodes[sub._node_handle]
+        sub._topic_name = str(event['topic_name'])
+        sub._queue_depth = event['queue_depth']
+
+    for event in event_data['ros2:rclcpp_subscription_callback_added']:
+        sub = None
+        for s in temp_subs:
+            if s._reference == event['subscription']:
+                sub = s
+                break
+        if sub is None:
+            # print("Could not associate subscription callback")
+            continue
+
+        sub._callback_handle = event['callback']
+
+        if sub._callback_handle in graph._callbacks:
+            sub._callback = graph._callbacks[sub._callback_handle]
+
+
+    for event in event_data['ros2:rmw_subscription_init']:
+        sub = None
+        for s in temp_subs:
+            if s._rmw_handle == event['rmw_subscription_handle']:
+                sub = s
+                break
+        if sub is None:
+            # print("Could not associate rmw subscription")
+            continue
+
+        sub._rmw_init_time = event['_timestamp']
+        sub._gid = [*event['gid']][0:16]
+
+    for event in event_data['dds:create_reader']:
+        sub = None
+        for s in temp_subs:
+            if s._gid == event['gid']:
+                sub = s
+                break
+        if not sub:
+            # print(f"Could not associate dds reader: {event['topic_name']}")
+            continue
+
+        sub._dds_init_time = event['_timestamp']
+        sub._dds_topic_name = event['topic_name']
+        sub._dds_reader = event['reader']
+
+    for sub in temp_subs:
+        graph.add_subscription(sub)
+
+
+def _build_timers(graph: Graph, event_data) -> None:
+    temp_timers = []
+    for event in event_data['ros2:rcl_timer_init']:
+        t = Timer(event['timer_handle'])
+        t._period = event['period']
+        t._rcl_init_time = event['_timestamp']
+        temp_timers.append(t)
+
+    for event in event_data['ros2:rclcpp_timer_link_node']:
+        timer = None
+        for t in temp_timers:
+            if t._handle == event['timer_handle']:
+                timer = t
+        if timer is None:
+            continue
+
+        timer._rclcpp_init_time = event['_timestamp']
+        timer._node_handle = event['node_handle']
+        if timer._node_handle in graph._nodes:
+            timer._node = graph._nodes[timer._node_handle]
+
+    for event in event_data['ros2:rclcpp_timer_callback_added']:
+        timer = None
+        for t in temp_timers:
+            if t._handle == event['timer_handle']:
+                timer = t
+        if timer is None:
+            continue
+
+        timer._callback_handle = event['callback']
+
+        if timer._callback_handle in graph._callbacks:
+            timer._callback = graph._callbacks[timer._callback_handle]
+
+    for timer in temp_timers:
+        graph.add_timer(timer)
+
+def _build_callback_events(graph: Graph, event_data) -> None:
+    events = []
+    for event in event_data['ros2:callback_start']:
+        events.append({
+            'event': 's',
+            'is_intra_process': event['is_intra_process'],
+            'timestamp': event['_timestamp'],
+            'callback': event['callback'],
+            'vpid': event['vpid'], 'vtid': event['vtid'], 'cpu_id': event['cpu_id']})
+    for event in event_data['ros2:callback_end']:
+        events.append({
+            'event': 'e',
+            'timestamp': event['_timestamp'],
+            'callback': event['callback'],
+            'vpid': event['vpid'], 'vtid': event['vtid'], 'cpu_id': event['cpu_id']})
+
+    df = pd.DataFrame(events)
+    df.sort_values(by=['callback','vpid', 'vtid', 'timestamp'], inplace=True)
+    df.reset_index(drop=True, inplace=True)
+
+    cur_event = None
+    events = []
+    for idx, row in df.iterrows():
+        if row['event'] == 's':
+            cur_event = CallbackEvent(row['callback'], row['is_intra_process'])
+            cur_event._callback_start = row['timestamp']
+            cur_event._vpid = row['vpid']
+            cur_event._vtid = row['vtid']
+            cur_event._cpu_id = row['cpu_id']
+        elif cur_event and row['event'] == 'e':
+            if (row['callback'] != cur_event._callback_handle or
+                row['vpid'] != cur_event._vpid or
+                row['vtid'] != cur_event._vtid):
+                print('error associating: ', idx)
+                cur_event=None
+                break
+            else:
+                cur_event._callback_end = row['timestamp']
+                events.append(cur_event)
+                cur_event = None
+
+    for event in events:
+        if event.handle() in graph._callbacks:
+            graph._callbacks[event.handle()]._events.append(event)
+        else:
+            # print("Could not associate CallbackEvent with Callback")
+            pass
+
+    for callback in graph._callbacks.values():
+        callback._events.sort(key=lambda ev: ev._callback_start)
+
+def _build_publish_events(graph: Graph, event_data):
+    events = []
+
+    for event in event_data['ros2:rclcpp_publish']:
+        events.append({
+            'event': 'rclcpp_publish',
+            'timestamp': event['_timestamp'],
+            'message': event['message'],
+            'vpid': event['vpid'], 'vtid': event['vtid'], 'cpu_id': event['cpu_id']
+        })
+
+    for event in event_data['ros2:rcl_publish']:
+        events.append({
+            'event': 'rcl_publish',
+            'timestamp': event['_timestamp'],
+            'message': event['message'],
+            'publisher_handle': event['publisher_handle'],
+            'vpid': event['vpid'], 'vtid': event['vtid'], 'cpu_id': event['cpu_id']
+        })
+
+    for event in event_data['ros2:rmw_publish']:
+        events.append({
+            'event': 'rmw_publish',
+            'timestamp': event['_timestamp'],
+            'message': event['message'],
+            'vpid': event['vpid'], 'vtid': event['vtid'], 'cpu_id': event['cpu_id']
+        })
+
+    for event in event_data['dds:write']:
+        events.append({
+            'event': 'dds_write',
+            'timestamp': event['_timestamp'],
+            'writer': event['writer'],
+            'message': event['data'],
+            'dds_timestamp': event['timestamp'],
+            'vpid': event['vpid'], 'vtid': event['vtid'], 'cpu_id': event['cpu_id']
+        })
+
+    df = pd.DataFrame(events)
+    df.sort_values(by=['message', 'vpid', 'vtid', 'timestamp'], inplace=True)
+    df.reset_index(drop=True, inplace=True)
+    df['used'] = False
+    used_idx = df.columns.get_loc('used')
+
+    print(f'Analyzing {len(df)} publish events, raw counts:')
+    print(f'  rclcpp_publish: {len(event_data["ros2:rclcpp_publish"])}')
+    print(f'  rcl_publish: {len(event_data["ros2:rcl_publish"])}')
+    print(f'  rmw_publish: {len(event_data["ros2:rmw_publish"])}')
+    print(f'  dds_write: {len(event_data["dds:write"])}')
+
+    cur_event = None
+    publish_events = []
+    for idx, row in df.iterrows():
+        if idx % 10000 == 0:
+            print(f'Analyzed {idx} events')
+
+        if row['event'] == 'rclcpp_publish':
+            cur_event = PublishEvent(row['message'])
+            cur_event._vpid = row['vpid']
+            cur_event._vtid = row['vtid']
+            cur_event._cpu_id = row['cpu_id']
+            cur_event._rclcpp_init_time = row['timestamp']
+            df.iloc[idx, used_idx] = True
+        elif cur_event and row['event'] == 'rcl_publish':
+            if (row['message'] != cur_event._message_handle or
+                row['vpid'] != cur_event._vpid or
+                row['vtid'] != cur_event._vtid):
+                continue
+            cur_event._rcl_init_time = row['timestamp']
+            cur_event._publisher_handle = row['publisher_handle']
+            df.iloc[idx, used_idx] = True
+        elif cur_event and row['event'] == 'rmw_publish':
+            if (row['message'] != cur_event._message_handle or
+                row['vpid'] != cur_event._vpid or
+                row['vtid'] != cur_event._vtid):
+                continue
+            cur_event._rmw_init_time = row['timestamp']
+            df.iloc[idx, used_idx] = True
+        elif cur_event and row['event'] == 'dds_write':
+            if (row['message'] != cur_event._message_handle or
+                row['vpid'] != cur_event._vpid or
+                row['vtid'] != cur_event._vtid):
+                continue
+            cur_event._dds_init_time = row['timestamp']
+            cur_event._dds_writer = row['writer']
+            cur_event._dds_timestamp = row['dds_timestamp']
+
+            df.iloc[idx, used_idx] = True
+            publish_events.append(cur_event)
+            cur_event = None
+
+    rclcpp_events_found = len(publish_events)
+    print(f'Found {rclcpp_events_found} complete rclcpp_publish events')
+
+    df2 = df[~df['used']].copy()
+    df2.reset_index(drop=True, inplace=True)
+
+    print(f'Evaluating {len(df2)} remaining events')
+
+    cur_event = None
+    for idx, row in df2.iterrows():
+        if row['event'] == 'rcl_publish':
+            cur_event = PublishEvent(row['message'])
+            cur_event._vpid = row['vpid']
+            cur_event._vtid = row['vtid']
+            cur_event._cpu_id = row['cpu_id']
+            cur_event._rcl_init_time = row['timestamp']
+            cur_event._publisher_handle = row['publisher_handle']
+            df2.iloc[idx, used_idx] = True
+        elif cur_event and row['event'] == 'rmw_publish':
+            if (row['message'] != cur_event._message_handle or
+                row['vpid'] != cur_event._vpid or
+                row['vtid'] != cur_event._vtid):
+                continue
+            cur_event._rmw_init_time = row['timestamp']
+            df2.iloc[idx, used_idx] = True
+
+        elif cur_event and row['event'] == 'dds_write':
+            if (row['message'] != cur_event._message_handle or
+                row['vpid'] != cur_event._vpid or
+                row['vtid'] != cur_event._vtid):
+                continue
+            cur_event._dds_init_time = row['timestamp']
+            cur_event._dds_writer = row['writer']
+            df2.iloc[idx, used_idx] = True
+            publish_events.append(cur_event)
+            cur_event = None
+    rcl_events_found = len(publish_events) - rclcpp_events_found
+    print(f'Found {rcl_events_found} additional rcl_publish only events')
+
+    for event in publish_events:
+        if event._publisher_handle in graph._publishers:
+            graph._publishers[event._publisher_handle]._events.append(event)
+
+    for publisher in graph._publishers.values():
+        publisher._events.sort(key=lambda ev: ev._rcl_init_time)
+
+def _build_subscription_events(graph: Graph, event_data):
+    events = []
+
+    for event in event_data['ros2:rclcpp_take']:
+        events.append({
+            'event': 'rclcpp_take',
+            'timestamp': event['_timestamp'],
+            'message': event['message'],
+            'vpid': event['vpid'], 'vtid': event['vtid'], 'cpu_id': event['cpu_id']
+        })
+    for event in event_data['ros2:rcl_take']:
+        events.append({
+            'event': 'rcl_take',
+            'timestamp': event['_timestamp'],
+            'message': event['message'],
+            'vpid': event['vpid'], 'vtid': event['vtid'], 'cpu_id': event['cpu_id']
+        })
+    for event in event_data['ros2:rmw_take']:
+        events.append({
+            'event': 'rmw_take',
+            'timestamp': event['_timestamp'],
+            'message': event['message'],
+            'rmw_subscription_handle': event['rmw_subscription_handle'],
+            'source_timestamp': event['source_timestamp'],
+            'taken': event['taken'],
+            'vpid': event['vpid'], 'vtid': event['vtid'], 'cpu_id': event['cpu_id']
+        })
+    for event in event_data['dds:read']:
+        events.append({
+            'event': 'dds_read',
+            'timestamp': event['_timestamp'],
+            'message': event['buffer'],
+            'reader': event['reader'],
+            'vpid': event['vpid'], 'vtid': event['vtid'], 'cpu_id': event['cpu_id']
+        })
+
+    df = pd.DataFrame(events)
+    df.sort_values(by=['vpid', 'vtid', 'timestamp'], inplace=True, ascending=False)
+    df.reset_index(drop=True, inplace=True)
+
+    cur_event = None
+    subscribe_events = []
+    for idx, row in df.iterrows():
+        if row['event'] == 'rclcpp_take':
+            cur_event = SubscriptionEvent(row['message'])
+            cur_event._vpid = row['vpid']
+            cur_event._vtid = row['vtid']
+            cur_event._cpu_id = row['cpu_id']
+            cur_event._rclcpp_init_time = row['timestamp']
+        elif cur_event and row['event'] == 'rcl_take':
+            if (row['message'] != cur_event._message_handle):
+                continue
+            cur_event._rcl_init_time = row['timestamp']
+        elif cur_event and row['event'] == 'rmw_take':
+            if (row['message'] != cur_event._message_handle):
+                continue
+            cur_event._rmw_init_time = row['timestamp']
+            cur_event._rmw_subscription_handle = int(row['rmw_subscription_handle'])
+        elif cur_event and row['event'] == 'dds_read':
+            if (row['message'] != cur_event._message_handle):
+                continue
+            cur_event._dds_init_time = row['timestamp']
+            cur_event._dds_reader = int(row['reader'])
+            subscribe_events.append(cur_event)
+            cur_event = None
+
+    print(f'Found {len(subscribe_events)} subscription events')
+
+    subs_by_rmw = {}
+    for sub in graph._subscriptions.values():
+        subs_by_rmw[sub._rmw_handle] = sub
+
+    for event in subscribe_events:
+        subs_by_rmw[event._rmw_subscription_handle]._events.append(event)
+
+    for subscription in graph._subscriptions.values():
+        subscription._events.sort(key=lambda ev: ev._rcl_init_time)
+
+def _associate_subscription_callbacks(graph: Graph, event_data):
+    for subscription in graph._subscriptions.values():
+        sub_events = subscription.events()
+        sub_cb_events = subscription.callback().events()
+
+        if len(sub_events) == 0:
+            print(f"No events for subscription: {subscription.topic_name()}")
+            continue
+        if len(sub_cb_events) == 0:
+            print(f"No callback events for subscription: {subscription.topic_name()}")
+            continue
+
+        if len(sub_events) != len(sub_cb_events):
+            print(f"Mismatch in event numbers for : {subscription.topic_name()}")
+            print(f" Subscription Events: {len(sub_events)}")
+            print(f" Callback Events: {len(sub_cb_events)}")
+
+        for (sub_event, callback_event) in zip(sub_events, sub_cb_events):
+            sub_event._callback = callback_event
+            callback_event._trigger = sub_event
+
+
+def _associate_pubsub(graph: Graph, event_data):
+    for topic in graph.topics():
+        events = []
+        if len(topic.subscriptions()) == 0 or len(topic.publishers()) == 0:
+            continue
+
+        for sub_idx, sub in enumerate(topic.subscriptions()):
+            for event_idx, ev in enumerate(sub.events()):
+                events.append({'type': 'sub',
+                               'topic_num': int(sub_idx),
+                               'event_num': int(event_idx),
+                               'ts': ev._dds_init_time})
+        for pub_idx, pub in enumerate(topic.publishers()):
+            for event_idx, ev in enumerate(pub.events()):
+                events.append({'type': 'pub',
+                               'topic_num': int(pub_idx),
+                               'event_num': int(event_idx),
+                               'ts': ev._dds_init_time})
+        if len(events) == 0:
+            continue
+
+        df = pd.DataFrame(events)
+        df.sort_values(by=['ts'], inplace=True, ascending=False)
+
+        cur_event = None
+        for idx, row in df.iterrows():
+            if row['type'] == 'sub':
+                cur_sub = topic.subscriptions()[row['topic_num']]
+                cur_event = cur_sub.events()[row['event_num']]
+            elif cur_event and row['type'] == 'pub':
+                cur_event._trigger = topic.publishers()[row['topic_num']].events()[row['event_num']]
+                cur_event = None

--- a/ros2profile/ros2profile/data/callback.py
+++ b/ros2profile/ros2profile/data/callback.py
@@ -1,0 +1,116 @@
+from typing import List
+
+def _prettify(
+    original: str,
+) -> str:
+    """
+    Process symbol to make it more readable.
+
+    * remove std::allocator
+    * remove std::default_delete
+    * bind object: remove placeholder
+
+    :param original: the original symbol
+    :return: the prettified symbol
+    """
+    pretty = original
+    # remove spaces
+    pretty = pretty.replace(' ', '')
+    # allocator
+    std_allocator = '_<std::allocator<void>>'
+    pretty = pretty.replace(std_allocator, '')
+    # default_delete
+    std_defaultdelete = 'std::default_delete'
+    if std_defaultdelete in pretty:
+        dd_start = pretty.find(std_defaultdelete)
+        template_param_open = dd_start + len(std_defaultdelete)
+        # find index of matching/closing GT sign
+        template_param_close = template_param_open
+        level = 0
+        done = False
+        while not done:
+            template_param_close += 1
+            if pretty[template_param_close] == '<':
+                level += 1
+            elif pretty[template_param_close] == '>':
+                if level == 0:
+                    done = True
+                else:
+                    level -= 1
+        pretty = pretty[:dd_start] + pretty[(template_param_close + 1):]
+    # bind
+    std_bind = 'std::_Bind<'
+    if pretty.startswith(std_bind):
+        # remove bind<>
+        pretty = pretty.replace(std_bind, '')
+        pretty = pretty[:-1]
+        # remove placeholder stuff
+        placeholder_from = pretty.find('*')
+        placeholder_to = pretty.find(')', placeholder_from)
+        pretty = pretty[:placeholder_from] + '?' + pretty[(placeholder_to + 1):]
+    # remove dangling comma
+    pretty = pretty.replace(',>', '>')
+    # restore meaningful spaces
+    if pretty.startswith('void'):
+        pretty = 'void' + ' ' + pretty[len('void'):]
+    if pretty.endswith('const'):
+        pretty = pretty[:(len(pretty) - len('const'))] + ' ' + 'const'
+    return pretty
+
+
+class Callback:
+    def __init__(self, callback_handle, symbol):
+        self._handle = callback_handle
+        self._symbol = symbol
+        self._rclcpp_init_time = None
+
+        self._events: List[CallbackEvent] = []
+
+
+    def handle(self) -> int:
+        return self._handle
+
+    def symbol(self) -> str:
+        return _prettify(self._symbol)
+
+    def num_calls(self) -> int:
+        return len(self._events)
+
+    def events(self):
+        return self._events
+
+    def __repr__(self) -> str:
+        return f'<Callback handle={self._handle}>'
+
+
+class CallbackEvent:
+    def __init__(self, callback_handle, is_intra_process):
+        self._callback_handle = callback_handle
+        self._is_intra_process = is_intra_process
+
+        self._callback_start: int = -1
+        self._callback_end:int = -1
+
+        self._vpid = None
+        self._vtid = None
+        self._cpu_id = None
+
+        self._trigger = None
+
+    def trigger(self):
+        return self._trigger
+
+    def handle(self) -> int:
+        return self._callback_handle
+
+    def start(self) -> int:
+        return self._callback_start
+
+    def end(self) -> int:
+        return self._callback_end
+
+    def duration(self) -> int:
+        return self.end() - self.start()
+
+    def __repr__(self) -> str:
+        return f'<CallbackEvent handle={self._callback_handle} start={self.start()} duration={self.duration()}>'

--- a/ros2profile/ros2profile/data/callback.py
+++ b/ros2profile/ros2profile/data/callback.py
@@ -65,7 +65,7 @@ class Callback:
         self._rclcpp_init_time = None
 
         self._events: List[CallbackEvent] = []
-
+        self._source = None
 
     def handle(self) -> int:
         return self._handle
@@ -96,9 +96,13 @@ class CallbackEvent:
         self._cpu_id = None
 
         self._trigger = None
+        self._source = None
 
     def trigger(self):
         return self._trigger
+
+    def source(self):
+        return self._source
 
     def handle(self) -> int:
         return self._callback_handle

--- a/ros2profile/ros2profile/data/context.py
+++ b/ros2profile/ros2profile/data/context.py
@@ -1,0 +1,7 @@
+class Context:
+    def __init__(self, context_handle: int, version: str):
+        self._handle = context_handle
+        self._version = version
+
+    def __repr__(self) -> str:
+        return f'<Context handle={self._handle} version={self._version}>'

--- a/ros2profile/ros2profile/data/convert/ctf.py
+++ b/ros2profile/ros2profile/data/convert/ctf.py
@@ -1,0 +1,109 @@
+# Copyright 2023 Open Source Robotics Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections import defaultdict
+from typing import Dict, Any, List
+
+import bt2
+
+DictEvent = Dict[str, Any]
+
+BT2_CONV_FUNC = {
+    'context_handle': int,
+    'node_handle': int,
+    'rmw_publisher_handle': int,
+    'rmw_subscription_handle': int,
+    'rmw_service_handle': int,
+    'subscription_handle': int,
+    'publisher_handle': int,
+    'service_handle': int,
+    'timer_handle': int,
+    'rmw_handle': int,
+    'node_name': str,
+    'namespace': str,
+    'version': str,
+    'vpid': int,
+    'vtid': int,
+    'cpu_id': int,
+    'reader': int,
+    'writer': int,
+    'message': int,
+    'callback': int,
+    'subscription': int,
+    'topic_name': str,
+    'service_name': str,
+    'procname': str,
+    'buffer': int,
+    'data': int,
+    'timestamp': int,
+    'source_timestamp': int,
+    'taken': bool,
+    'is_intra_process': bool,
+    'period': int,
+    'handle': int,
+    'timeout': int,
+    'queue_depth': int,
+    'symbol': str,
+    'state_machine': int,
+    'gid': lambda x: map(int, x)
+}
+
+LTTNG_IGNORE_NAMES = [
+    'kmem_mm_page_alloc',
+    'kmem_mm_page_free',
+    'lttng_ust_statedump:start',
+    'lttng_ust_statedump:procname',
+    'lttng_ust_lib:load',
+    'lttng_ust_lib:build_id',
+    'lttng_ust_lib:debug_link',
+    'lttng_ust_statedump:bin_info',
+    'lttng_ust_statedump:build_id',
+    'lttng_ust_statedump:debug_link',
+    'lttng_ust_statedump:end'
+]
+
+def payload_to_dict(payload) -> DictEvent:
+    if not payload:
+        return {}
+    else:
+        return {k: BT2_CONV_FUNC[k](v) for (k, v) in payload.items()}
+
+def event_to_dict(msg: bt2._EventMessageConst) -> DictEvent:
+    meta = {
+        '_name': str(msg.event.name),
+        '_timestamp': int(msg.default_clock_snapshot.ns_from_origin)
+    }
+
+    payload = payload_to_dict(msg.event.payload_field)
+    specific_context = payload_to_dict(msg.event.specific_context_field)
+    common_context = payload_to_dict(msg.event.common_context_field)
+    packet_context = payload_to_dict(msg.event.packet.context_field)
+    return {**meta,
+            **payload,
+            **specific_context,
+            **common_context,
+            **packet_context}
+
+def load_ctf(directory: str, ignore_names: List[str] = LTTNG_IGNORE_NAMES) -> Dict[str, List[DictEvent]]:
+    msg_it = bt2.TraceCollectionMessageIterator(directory)
+    events = defaultdict(list)
+
+    for msg in msg_it:
+        if (type(msg) is not bt2._EventMessageConst or
+            msg.event.name in ignore_names):
+            continue
+        pod = event_to_dict(msg)
+        del pod['procname']
+        events[pod['_name']].append(pod)
+    return events

--- a/ros2profile/ros2profile/data/event.py
+++ b/ros2profile/ros2profile/data/event.py
@@ -1,0 +1,31 @@
+from abc import ABC, abstractmethod
+
+class EventSource(ABC):
+    def __init__(self):
+        pass
+
+class Event(ABC):
+    def __init__(self):
+        self._trigger: Event|None = None
+        self._source: EventSource|None = None
+
+    def set_trigger(self, trigger: Event) -> None:
+        self._trigger = trigger
+
+    def trigger(self) -> Event:
+        """
+        The preceeding event that caused this event to occur
+        """
+        return self._trigger
+
+    def set_source(self, source: EventSource) -> None:
+        self._source = source
+
+    def source(self) -> EventSource:
+        """
+        Graph member that emits these events (eg publisher, subscription, timer)
+        """
+        return self._source
+
+    def __repr__(self) -> str:
+        return f'<Event>'

--- a/ros2profile/ros2profile/data/graph.py
+++ b/ros2profile/ros2profile/data/graph.py
@@ -1,0 +1,78 @@
+from typing import List
+
+from .callback import Callback
+from .context import Context
+from .publisher import Publisher
+from .subscription import Subscription
+from .node import Node
+from .topic import Topic
+from .timer import Timer
+
+from .utils import filter_topics
+
+
+class Graph:
+    def __init__(self):
+        self._contexts = {}
+        self._nodes = {}
+        self._callbacks = {}
+        self._publishers = {}
+        self._subscriptions = {}
+        self._topics = {}
+        self._timers = {}
+
+    def add_context(self, context: Context):
+        self._contexts[context._handle] = context
+
+    def contexts(self) -> List[Context]:
+        return list(self._contexts.values())
+
+    def add_node(self, node: Node):
+        self._nodes[node._handle] = node
+
+    def nodes(self, node_name=None) -> List[Node]:
+        if node_name:
+            ret = []
+            for node in self._nodes.values():
+                if node.name().find(node_name) >= 0:
+                    ret.append(node)
+            return ret
+        else:
+            return list(self._nodes.values())
+
+    def add_callback(self, callback: Callback) -> None:
+        self._callbacks[callback._handle] = callback
+
+    def add_publisher(self, publisher: Publisher) -> None:
+        self._publishers[publisher.handle()] = publisher
+
+        topic = publisher.topic_name()
+        if topic not in self._topics:
+            self._topics[topic] = Topic(topic)
+        self._topics[topic].add_publisher(publisher)
+        self._nodes[publisher._node_handle]._publishers.append(publisher)
+
+    def publishers(self, rosout=False, parameter_events=False) -> List[Publisher]:
+        return filter_topics(self._publishers.values(), rosout, parameter_events)
+
+    def add_subscription(self, subscription: Subscription):
+        self._subscriptions[subscription.handle()] = subscription
+        topic = subscription.topic_name()
+        if topic not in self._topics:
+            self._topics[topic] = Topic(topic)
+        self._topics[topic].add_subscription(subscription)
+        self._nodes[subscription._node_handle]._subscriptions.append(subscription)
+
+    def subscriptions(self, rosout=False, parameter_events=False) -> List[Subscription]:
+        return filter_topics(self._subscriptions.values(), rosout, parameter_events)
+
+    def topics(self, rosout=False, parameter_events=False) -> List[Topic]:
+        return filter_topics(self._topics.values(), rosout, parameter_events)
+
+    def add_timer(self, timer: Timer) -> None:
+        self._timers[timer.handle()] = timer
+        if timer._node_handle in self._nodes:
+            self._nodes[timer._node_handle]._timers.append(timer)
+
+    def timers(self) -> List[Timer]:
+        return list(self._timers.values())

--- a/ros2profile/ros2profile/data/node.py
+++ b/ros2profile/ros2profile/data/node.py
@@ -1,0 +1,30 @@
+from .utils import filter_topics
+
+class Node:
+    def __init__(self, node_handle: int, node_name: str, namespace: str, rmw_handle: int):
+        self._handle = node_handle
+        self._name = node_name
+        self._namespace = namespace
+        self._rmw_handle = rmw_handle
+
+        self._publishers = []
+        self._subscriptions = []
+        self._timers = []
+
+    def __repr__(self) -> str:
+        return f'<Node handle={self._handle} name={self._name}>'
+
+    def name(self) -> str:
+        return self._name
+
+    def namespace(self) -> str:
+        return self._namespace
+
+    def timers(self):
+        return self._timers
+
+    def publishers(self):
+        return filter_topics(self._publishers)
+
+    def subscriptions(self):
+        return filter_topics(self._subscriptions)

--- a/ros2profile/ros2profile/data/publisher.py
+++ b/ros2profile/ros2profile/data/publisher.py
@@ -4,6 +4,7 @@ from .node import Node
 
 from typing import List
 
+
 class PublishEvent:
     def __init__(self, message_handle):
         self._message_handle = message_handle
@@ -18,8 +19,17 @@ class PublishEvent:
         self._dds_init_time = None
         self._dds_timestamp = None
 
+        self._trigger = None
+        self._source = None
+
+    def trigger(self):
+        return self._trigger
+
+    def source(self):
+        return self._source
+
     def __repr__(self) -> str:
-        return f'<PublisherEvent handle={self._message_handle}>'
+        return f'<PublishEvent handle={self._message_handle}>'
 
 class Publisher:
     def __init__(self, publisher_handle):

--- a/ros2profile/ros2profile/data/publisher.py
+++ b/ros2profile/ros2profile/data/publisher.py
@@ -1,0 +1,60 @@
+from rclpy.expand_topic_name import expand_topic_name
+
+from .node import Node
+
+from typing import List
+
+class PublishEvent:
+    def __init__(self, message_handle):
+        self._message_handle = message_handle
+
+        self._vpid = None
+        self._vtid = None
+        self._cpu_id = None
+
+        self._rclcpp_init_time = None
+        self._rcl_init_time = None
+        self._rmw_init_time = None
+        self._dds_init_time = None
+        self._dds_timestamp = None
+
+    def __repr__(self) -> str:
+        return f'<PublisherEvent handle={self._message_handle}>'
+
+class Publisher:
+    def __init__(self, publisher_handle):
+        self._handle = publisher_handle
+        self._node = None
+        self._node_handle = None
+
+        self._rmw_handle = None
+        self._gid = None
+
+        self._topic_name = None
+        self._queue_depth = None
+
+        self._rclcpp_init_time = None
+        self._rcl_init_time = None
+        self._rmw_init_time = None
+        self._dds_init_time = None
+
+        self._dds_topic_name = None
+        self._dds_writer = None
+
+        self._events: List[PublishEvent] = []
+
+    def events(self):
+        return self._events
+
+    def handle(self) -> int:
+        return self._handle
+
+    def topic_name(self) -> str:
+        return expand_topic_name(self._topic_name,
+            self._node.name(), self._node.namespace())
+
+    def node(self) -> Node:
+        return self._node
+
+    def __repr__(self) -> str:
+        return f'<Publisher handle={self._handle} topic_name={self.topic_name()}>'

--- a/ros2profile/ros2profile/data/service.py
+++ b/ros2profile/ros2profile/data/service.py
@@ -1,0 +1,34 @@
+from rclpy.expand_topic_name import expand_topic_name
+
+from .callback import Callback
+from .node import Node
+
+class ServiceServer:
+    def __init__(self, service_handle: int):
+        self._handle = service_handle
+        self._node = None
+        self._node_handle = None
+        self._rmw_handle = None
+
+        self._service_name = None
+
+        self._rclcpp_init_time = None
+        self._rcl_init_time = None
+
+        self._callback_handle = None
+        self._callback = None
+
+    def handle(self) -> int:
+        return self._handle
+
+    def node(self) -> Node:
+        return self._node
+
+    def service_name(self):
+        return self._service_name
+
+    def callback(self) -> Callback:
+        return self._callback
+
+    def __repr__(self) -> str:
+        return f'<ServiceServer handle={self._handle} service_name={self.service_name()}>'

--- a/ros2profile/ros2profile/data/subscription.py
+++ b/ros2profile/ros2profile/data/subscription.py
@@ -1,0 +1,66 @@
+from rclpy.expand_topic_name import expand_topic_name
+
+from .callback import Callback
+from .node import Node
+
+from typing import List
+
+class SubscriptionEvent:
+    def __init__(self, message_handle):
+        self._message_handle = message_handle
+
+        self._vpid = None
+        self._vtid = None
+        self._cpu_id = None
+
+        self._rclcpp_init_time = None
+        self._rcl_init_time = None
+        self._rmw_init_time = None
+        self._dds_init_time = None
+        self._dds_timestamp = None
+
+        self._dds_reader = None
+
+        self._callback = None
+
+class Subscription:
+    def __init__(self, subscription_handle, subscription_reference):
+        self._handle = subscription_handle
+        self._reference = subscription_reference
+        self._node = None
+        self._node_handle = None
+
+        self._rmw_handle = None
+        self._gid = None
+
+        self._topic_name = None
+        self._queue_depth = None
+
+        self._rclcpp_init_time = None
+        self._rcl_init_time = None
+        self._rmw_init_time = None
+        self._dds_init_time = None
+
+        self._dds_topic_name = None
+        self._dds_reader = None
+
+        self._events = []
+
+    def handle(self) -> int:
+        return self._handle
+
+    def topic_name(self) -> str:
+        return expand_topic_name(self._topic_name,
+            self._node.name(), self._node.namespace())
+
+    def node(self) -> Node:
+        return self._node
+
+    def events(self) -> List[SubscriptionEvent]:
+        return self._events
+
+    def callback(self) -> Callback:
+        return self._callback
+
+    def __repr__(self) -> str:
+        return f'<Subscription handle={self._handle} topic_name={self.topic_name()}>'

--- a/ros2profile/ros2profile/data/subscription.py
+++ b/ros2profile/ros2profile/data/subscription.py
@@ -23,6 +23,15 @@ class SubscriptionEvent:
 
         self._callback = None
 
+        self._trigger = None
+        self._source = None
+
+    def trigger(self):
+        return self._trigger
+
+    def source(self):
+        return self._source
+
 class Subscription:
     def __init__(self, subscription_handle, subscription_reference):
         self._handle = subscription_handle

--- a/ros2profile/ros2profile/data/timer.py
+++ b/ros2profile/ros2profile/data/timer.py
@@ -1,0 +1,39 @@
+from .callback import Callback
+from .node import Node
+
+import numpy as np
+
+class Timer:
+    def __init__(self, timer_handle):
+        self._handle = timer_handle
+        self._period: int = -1
+
+        self._node: Node = None
+        self._node_handle = None
+
+
+        self._rclcpp_init_time = None
+        self._rcl_init_time = None
+
+        self._callback_handle = None
+        self._callback: Callback = None
+
+    def handle(self) -> int:
+        return self._handle
+
+    def node(self) -> Node:
+        return self._node
+
+    def callback(self) -> Callback:
+        return self._callback
+
+    def period(self) -> int:
+        return self._period
+
+    def mean_period(self) -> int:
+        calls = np.array([ev.start() for ev in self.callback().events()])
+        return np.mean(np.diff(calls))
+
+
+    def __repr__(self) -> str:
+        return f'<Timer handle={self._handle} period={self._period}>'

--- a/ros2profile/ros2profile/data/timer.py
+++ b/ros2profile/ros2profile/data/timer.py
@@ -11,7 +11,6 @@ class Timer:
         self._node: Node = None
         self._node_handle = None
 
-
         self._rclcpp_init_time = None
         self._rcl_init_time = None
 

--- a/ros2profile/ros2profile/data/topic.py
+++ b/ros2profile/ros2profile/data/topic.py
@@ -1,0 +1,28 @@
+from .publisher import Publisher
+from .subscription import Subscription
+
+from typing import List
+
+class Topic:
+    def __init__(self, topic_name: str):
+        self._topic_name = topic_name
+        self._publishers = []
+        self._subscriptions = []
+
+    def add_publisher(self, publisher: Publisher) -> None:
+        self._publishers.append(publisher)
+
+    def add_subscription(self, subscription: Subscription) -> None:
+        self._subscriptions.append(subscription)
+
+    def topic_name(self) -> str:
+        return self._topic_name
+
+    def publishers(self) -> List[Publisher]:
+        return self._publishers
+
+    def subscriptions(self) -> List[Subscription]:
+        return self._subscriptions
+
+    def __repr__(self) -> str:
+        return f'<Topic name={self._topic_name}>'

--- a/ros2profile/ros2profile/data/utils.py
+++ b/ros2profile/ros2profile/data/utils.py
@@ -1,0 +1,9 @@
+def filter_topics(collection, rosout: bool = False, parameter_events: bool = False):
+    ret = []
+    for val in collection:
+        if not rosout and val.topic_name().find('rosout') >= 0:
+            continue
+        if not parameter_events and val.topic_name().find('parameter_events') >= 0:
+            continue
+        ret.append(val)
+    return ret

--- a/ros2profile/ros2profile/verb/process.py
+++ b/ros2profile/ros2profile/verb/process.py
@@ -1,8 +1,5 @@
 from ros2profile.verb import VerbExtension
-
 from ros2profile.api.process import process
-
-import tracetools_analysis.process
 
 class ProcessVerb(VerbExtension):
     def add_arguments(self, parser, cli_name):  #noqa: D102
@@ -11,9 +8,5 @@ class ProcessVerb(VerbExtension):
         )
 
     def main(self, *, args):
-        # Process the trace
-        tracetools_analysis.process.process(
-                args.input_path + 'ros2profile-tracing-session', False, True, False)
-
-        # Process topnode results
+        # Process results
         process(args.input_path)

--- a/ros2profile/test/conftest.py
+++ b/ros2profile/test/conftest.py
@@ -1,37 +1,9 @@
 import pytest
 
-import os
-import yaml
-
-from ros2profile.api.process import load_files, load_trace
+from ros2profile.api.process import load_mcap_data, load_event_graph
 
 def pytest_addoption(parser):
     parser.addoption("--input-dir", action="store")
-
-
-class ProfileDataModel():
-    def __init__(self, input_dir):
-        self.input_dir = input_dir
-
-        with open(os.path.join(input_dir, 'config.yaml'), 'r') as f:
-            self.config = yaml.load(f, Loader=yaml.SafeLoader)
-        self.trace_data = load_trace(input_dir)
-        self.mcap_data = load_files(input_dir)
-
-    def containers(self):
-        return self.config['containers']
-
-    def nodes(self):
-        return self.config['nodes']
-
-    def node_handle(self, node_name):
-        return self.trace_data.data.nodes[
-            self.trace_data.data.nodes.name == node_name
-        ].to_dict()
-
-    def cpu_memory_usage(self, container):
-        assert container in self.mcap_data
-        return self.mcap_data[container]['~/cpu_memory_usage']
 
 
 @pytest.fixture(scope='session')
@@ -46,4 +18,12 @@ def profile_data(request):
     input_dir = request.config.option.input_dir
     if input_dir is None:
         pytest.skip()
-    return ProfileDataModel(input_dir)
+    return load_mcap_data(input_dir)
+
+@pytest.fixture(scope='session')
+def profile_event_graph(request):
+    input_dir = request.config.option.input_dir
+    if input_dir is None:
+        pytest.skip()
+    return load_event_graph(input_dir)
+

--- a/ros2profile/test/test_graph.py
+++ b/ros2profile/test/test_graph.py
@@ -1,0 +1,42 @@
+import numpy as np
+
+def test_graph(profile_event_graph):
+    graph = profile_event_graph
+    assert len(graph.nodes()) == 24
+    assert len(graph.topics()) == 25
+    assert len(graph.publishers()) == 25
+    assert len(graph.subscriptions()) == 36
+
+
+def test_graph_hamburg(profile_event_graph):
+    graph = profile_event_graph
+
+    # Retrieve a node by name
+    matching_nodes = profile_event_graph.nodes('hamburg')
+    assert len(matching_nodes) == 1
+    hamburg = matching_nodes[0]
+
+    # Check node publishers and subscriptions
+    assert len(hamburg.timers()) == 0
+    assert len(hamburg.publishers()) == 1
+    assert len(hamburg.subscriptions()) == 4
+
+    # Evaluate each subscriptions' callback duration
+    for sub in hamburg.subscriptions():
+        durations = [e.duration() for e in sub.callback().events()]
+        assert np.mean(durations) < 1e5  # ns
+        assert np.std(durations) < 1e5  # ns
+
+    pub = hamburg.publishers()[0]
+    events = np.array([ev._rclcpp_init_time for ev in pub.events()])
+
+    pub_deltas = np.diff(events) / 1e9
+    period = np.mean(pub_deltas)
+    stddev = np.std(pub_deltas)
+
+    # Period should be every 200 ms
+    # Assert mean within 1 microsecond
+    # Assert std within 1 millisecond
+    assert np.abs(period - 0.2) < 1e-6
+    assert np.abs(period - 0.2) < 1e-6
+    assert stddev < 1e-3

--- a/ros2profile/test/test_profile.py
+++ b/ros2profile/test/test_profile.py
@@ -1,15 +1,5 @@
 
 
-def test_nodes(profile_data):
-    assert len(profile_data.nodes()) == 20
-
-    # Assert that all of the nodes under test are available
-    # in the tracing data
-    for node in profile_data.nodes():
-        handle = profile_data.node_handle(node['name'])
-        assert handle
-
-
 def test_cpu(profile_data):
     containers = profile_data.containers()
     for container in containers:
@@ -22,49 +12,4 @@ def test_memory_usage(profile_data):
     for container in containers:
         usage = profile_data.cpu_memory_usage(container['name'])
         assert (usage['memory_percent'] < 0.01).all()
-
         assert(usage['memory_percent'].median() < 1.0)
-
-
-def test_callback_durations(profile_data):
-    callbacks = []
-    durations = []
-
-    trace = profile_data.trace_data
-
-    callback_symbols = trace.get_callback_symbols()
-    for obj, symbol in callback_symbols.items():
-
-        reference = trace.data.callback_objects.loc[
-                    trace.data.callback_objects['callback_object'] == obj
-                ].index.values.astype(int)[0]
-
-        if reference in trace.data.timers.index:
-            type_name = 'Timer'
-            info = trace.get_timer_handle_info(reference)
-        elif reference in trace.data.rcl_publishers.index:
-            type_name = 'Publisher'
-            info = trace.get_publisher_handle_info(reference)
-        elif reference in trace.data.subscription_objects.index:
-            type_name = 'Subscription'
-            info = trace.get_subscription_reference_info(reference)
-        elif reference in trace.data.services.index:
-            type_name = 'Service'
-            info = trace.get_service_handle_info(reference)
-        elif reference in trace.data.clients.index:
-            type_name = 'Client'
-            info = trace.get_client_handle_info(reference)
-
-        if 'topic' in info and info['topic'] == '/parameter_events':
-            continue
-
-        info['symbol'] = symbol
-
-        duration_df = trace.get_callback_durations(obj)
-        callbacks.append((info, duration_df))
-
-
-    for (callback, duration_df) in callbacks:
-        if callback['node'] == 'georgetown':
-            print(callback['node'],
-            assert (duration_df['duration'].mean().microseconds < 2e3)


### PR DESCRIPTION
This introduces an alternative mechanism for interacting with trace data introduced in [https://github.com/ros-tracing/tracetools_analysis].

The primary data structure is a graph that represents the ROS 2 computation graph. From this entrypoint, users can introspect on the runtime layout of a traced ROS 2 system as recorded via tracetools.

In addition to the individual events, the data is associated across elements via:

1. Publication and Subscription events on the same topic are associated
2. Publications from within timer callbacks are associated
3. Publications from within subscription callbacks are associated.

This allows users to inspect causal "chains" of events across a ROS 2 computation graph.

As an example, in the [Mont Blanc test topology](https://github.com/safe-ros/reference_system/issues/3), we can trace the sequence of events to cause the `arequipa` subscription to be fired:


node | event | topic | timestamp (ms)
-- | -- | -- | --
portsmouth | callback_start | timer | 0.000000
portsmouth | rclcpp_pub | /danube | 0.023422
portsmouth | rcl_pub | /danube | 0.025456
portsmouth | rmw_pub | /danube | 0.025918
portsmouth | callback_end | timer | 0.069164
hamburg | rmw_take | /danube | 0.172475
hamburg | rcl_take | /danube | 0.172953
hamburg | rclcpp_take | /danube | 0.173848
hamburg | callback_start | /danube | 0.182634
hamburg | rclcpp_pub | /parana | 0.206418
hamburg | rcl_pub | /parana | 0.208355
hamburg | rmw_pub | /parana | 0.209520
hamburg | callback_end | /danube | 0.315995
geneva | rmw_take | /parana | 0.339240
geneva | rcl_take | /parana | 0.339772
geneva | rclcpp_take | /parana | 0.340232
geneva | callback_start | /parana | 0.341611
geneva | rclcpp_pub | /arkansas | 0.354110
geneva | rcl_pub | /arkansas | 0.355227
geneva | rmw_pub | /arkansas | 0.356448
geneva | callback_end | /parana | 0.398542
arequipa | rmw_take | /arkansas | 0.454997
arequipa | rcl_take | /arkansas | 0.455474
arequipa | rclcpp_take | /arkansas | 0.456482
arequipa | callback_start | /arkansas | 0.462663
arequipa | callback_end | /arkansas | 0.466198

