### PR TITLE
Add missing python deps and rosdep invoke

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ cd ~/safe_ros
 # Download and import repos file
 wget https://raw.githubusercontent.com/safe-ros/ros2_profiling/main/ros2_profiling_demo/demo.repos
 vcs import src < demo.repos 
+rosdep install --from-paths src --ignore-src -r -y
 ```
 
 

--- a/ros2profile/package.xml
+++ b/ros2profile/package.xml
@@ -11,6 +11,8 @@
   <depend>tracetools_trace</depend>
   <depend>tracetools_analysis</depend>
   <depend>topnode</depend>
+  <depend>python3-pandas</depend>
+  <depend>mcap-ros2-support</depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>


### PR DESCRIPTION
Closes #5 

https://github.com/ros/rosdistro/pull/36081 needs to be merged before the `mcap-ros2-support` pip package can be satisfied by `rosdep`

In the meantime, `pip install mcap-ros2-support` should be sufficient.

Signed-off-by: Michael Carroll <michael@openrobotics.org>