### PR TITLE
Introduce trigger properties

### DIFF
--- a/ros2profile/ros2profile/data/publisher.py
+++ b/ros2profile/ros2profile/data/publisher.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, List
+from typing import Dict, List, Any
 from rclpy.expand_topic_name import expand_topic_name
 
 from .graph_entity import GraphEntity
@@ -53,8 +53,14 @@ class PublishEvent:
     def source(self, value: 'Publisher') -> None:
         self._source = value
 
-    def trigger(self):
+    @property
+    def trigger(self) -> Any:
         return self._trigger
+
+    @trigger.setter
+    def trigger(self, value: Any):
+        self._trigger = value
+
 
     def __repr__(self) -> str:
         return f"<PublishEvent handle={self._handle}>"

--- a/ros2profile/ros2profile/data/subscription.py
+++ b/ros2profile/ros2profile/data/subscription.py
@@ -81,8 +81,13 @@ class SubscriptionEvent:
     def source_timestamp(self, value: int) -> None:
         self._source_timestamp = value
 
-    def trigger(self):
+    @property
+    def trigger(self) -> Any:
         return self._trigger
+
+    @trigger.setter
+    def trigger(self, value: Any):
+        self._trigger = value
 
     def __repr__(self) -> str:
         return f"<SubscriptionEvent handle={self._handle}>"


### PR DESCRIPTION
The triggers are now properties. Before it were a getter-like function. But then I'm not quite sure how https://github.com/safe-ros/ros2_profiling/blob/main/ros2profile/ros2profile/data/__init__.py#L529 even worked. I guess the member function was overwritten with a value? However, this PR makes it more consistent.