### PR TITLE
Warn if traces have been dropped

### DIFF
--- a/ros2profile/ros2profile/data/convert/ctf.py
+++ b/ros2profile/ros2profile/data/convert/ctf.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import lzma
 import pickle
 
@@ -115,6 +116,8 @@ def load_ctf(directory: str, ignore_names: List[str] = LTTNG_IGNORE_NAMES) -> Ct
     events = defaultdict(list)
 
     for msg in msg_it:
+        if type(msg) is bt2._DiscardedEventsMessageConst:
+           logging.warning("Trace lost packets! Data association may fail! Measurements may be missing!")
         if type(msg) is not bt2._EventMessageConst or msg.event.name in ignore_names:
             continue
         pod = event_to_dict(msg)


### PR DESCRIPTION
Analysis may fail, if important traces are missing. In this case it is really helpful to know, why.