### PR TITLE
Extend bt2 keys

### DIFF
--- a/ros2profile/ros2profile/data/convert/ctf.py
+++ b/ros2profile/ros2profile/data/convert/ctf.py
@@ -74,6 +74,11 @@ BT2_CONV_FUNC: Dict[str, ConversionFunction] = {
     "index": int,
     "size": int,
     "overwritten": bool,
+    "ptr": int,
+    "nmemb": int,
+    "in_ptr": int,
+    "alignment": int,
+    "memptr": int,
 }
 
 LTTNG_IGNORE_NAMES = [

--- a/ros2profile/ros2profile/data/convert/ctf.py
+++ b/ros2profile/ros2profile/data/convert/ctf.py
@@ -81,6 +81,14 @@ BT2_CONV_FUNC: Dict[str, ConversionFunction] = {
     "memptr": int,
     "mutex": int,
     "status": int,
+    "prev_comm": str,
+    "prev_tid": int,
+    "prev_prio": int,
+    "prev_state": int,
+    "next_comm": str,
+    "next_tid": int,
+    "next_prio": int,
+
 }
 
 LTTNG_IGNORE_NAMES = [

--- a/ros2profile/ros2profile/data/convert/ctf.py
+++ b/ros2profile/ros2profile/data/convert/ctf.py
@@ -79,6 +79,8 @@ BT2_CONV_FUNC: Dict[str, ConversionFunction] = {
     "in_ptr": int,
     "alignment": int,
     "memptr": int,
+    "mutex": int,
+    "status": int,
 }
 
 LTTNG_IGNORE_NAMES = [


### PR DESCRIPTION
Addition of the keys adds support for the tracepoints provided by:
- _liblttng-ust-libc-wrapper.so_
- _liblttng-ust-pthread-wrapper.so_
- _sched_switch_ kernel event

For reference: https://lttng.org/docs/v2.13/#doc-prebuilt-ust-helpers