### PR TITLE
Add customization points (by using 'entry_points') for including thir…

### DIFF
--- a/ros2profile/ros2profile/data/__init__.py
+++ b/ros2profile/ros2profile/data/__init__.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 from typing import Dict, Any, List, Optional
 
 from collections import defaultdict
 
+import importlib
 import logging
 import os
 
@@ -147,6 +149,12 @@ def build_graph(
         and process_subscription_events
     ):
         _associate_publish_events_to_subscription_callbacks(ret)
+
+    for name, ep in importlib.metadata.entry_points(group='ros2profile.extend_graph'):
+        logger.debug(f"Executing custom extension '{name}'.")
+        extend_graph = ep.load()
+        extend_graph(ret, event_data)
+
     return ret
 
 

--- a/ros2profile/ros2profile/data/convert/ctf.py
+++ b/ros2profile/ros2profile/data/convert/ctf.py
@@ -91,6 +91,12 @@ BT2_CONV_FUNC: Dict[str, ConversionFunction] = {
 
 }
 
+import importlib
+
+for field_name, conversion_function  in importlib.metadata.entry_points(group='ros2profile.custom_conversion_functions'):
+    logging.debug("Add custom conversion function for " + field_name)
+    BT2_CONV_FUNC[field_name] = conversion_function.load()
+
 LTTNG_IGNORE_NAMES = [
     "kmem_mm_page_alloc",
     "kmem_mm_page_free",


### PR DESCRIPTION
…d party tracepoints in graph.

It is now possible to create extensions for ros2_profile.

- With the extension point 'ros2profile.custom_conversion_functions' thirdparty packages can define custom conversion function for parsing new (otherwise unsupported) tracepoints.
- With the extension point 'ros2profile.extend_graph' thirdparty packages can define extension which may incorporate new (custom) tracepoints into the graph.

The setup.py of an extentsion package could look like this:  [setup.py.txt](https://github.com/safe-ros/ros2_profiling/files/14209249/setup.py.txt)
